### PR TITLE
feat(prefer-destructuring): don't enforce destructuring for assignments

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,10 @@ module.exports = {
     "no-var": "error",
     "object-shorthand": "error",
     "prefer-const": "error",
-    "prefer-destructuring": "error",
+    "prefer-destructuring": [
+      "error",
+      { AssignmentExpression: { array: false, object: false } }
+    ],
     "prefer-rest-params": "error",
     "prefer-spread": "error",
     "prefer-template": "error",


### PR DESCRIPTION
This configuration fixes, that re-assignments enforce destructuring,
which enforced weird code like this:

```js
let foo;

if (bar) {
  ({ foo } = baz);
} else {
  foo = 1
}
```